### PR TITLE
Pin protobuf version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 tensorflow==2.8.0
+protobuf==3.20
 faiss-cpu==1.7.2
 pillow==9.0.0
 flask==2.0.3


### PR DESCRIPTION
Tensorflow in particular is only compatible with certain versions
of protobuf.

----

Tested on CDSW nightly build.